### PR TITLE
Fix incorrect processor information

### DIFF
--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -349,7 +349,7 @@ if($gather_subset.Contains('processor')) {
     }
 
     $cpu_list = @( )
-    for ($i=1; $i -le ($win32_cpu.NumberOfLogicalProcessors / $win32_cs.NumberOfProcessors); $i++) {
+    for ($i=1; $i -le $win32_cs.NumberOfProcessors; $i++) {
         $cpu_list += $win32_cpu.Manufacturer
         $cpu_list += $win32_cpu.Name
     }
@@ -358,8 +358,8 @@ if($gather_subset.Contains('processor')) {
         ansible_processor = $cpu_list
         ansible_processor_cores = $win32_cpu.NumberOfCores
         ansible_processor_count = $win32_cs.NumberOfProcessors
-        ansible_processor_threads_per_core = ($win32_cpu.NumberOfLogicalProcessors / $win32_cs.NumberOfProcessors / $win32_cpu.NumberOfCores)
-        ansible_processor_vcpus = ($win32_cpu.NumberOfLogicalProcessors / $win32_cs.NumberOfProcessors)
+        ansible_processor_threads_per_core = ($win32_cpu.NumberOfLogicalProcessors / $win32_cpu.NumberofCores)
+        ansible_processor_vcpus = ($win32_cpu.NumberOfLogicalProcessors * $win32_cs.NumberOfProcessors)
     }
 }
 


### PR DESCRIPTION
Fixes Issue #45869 
Windows Processor Information Incorrect from Setup

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #45869 - changes to how ansible_processor fields are evaluated in setup module

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
setup module for Windows hosts setup.ps1
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/jdkaufman/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /venv/windows/lib/python2.7/site-packages/ansible
  executable location = /venv/windows/bin/ansible
  python version = 2.7.5 (default, Feb 20 2018, 09:19:12) [GCC 4.8.5 20150623 (Red Hat 4.8.5-28)]

```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
 Currently, setup returns values for ansible_processor, ansible_processor_threads_per_core, and ansible_processor_vcpus.  
The ansible_processor field should equal to the number of instances of Win32_Processor. ansible_processor_count should be equal to the number of CPU sockets ( which should equal the instances of Win32_Processor and equal the value of the Win32_ComputerSystem property NumberofProcessors).  Currently, it is empty in some cases and contains a incorrect amount of processors in others.  
 ansible_processor_core should be the number of cores which should equal Win32_Processor property NumberofCores. 
ansible_processor_threads_per_core should indicate if Hyper-Threading exists in processor and should be the Win32_Processor property NumberofLogicalCores divided by the Win32_Processor property NumberofCores. 
ansible_processor_vcpus should be number of vcpus available on the box which should be the total cores (including HT) available which should be ansible_processor_cores * ansible_processor_count * ansible_processor_threads_per_core.

```
